### PR TITLE
feat(markdown): new function for rag system

### DIFF
--- a/tests/markdown/test_manipulator.py
+++ b/tests/markdown/test_manipulator.py
@@ -1,6 +1,136 @@
 import pytest
-from ures.markdown import MarkdownDocument
+from ures.markdown import MarkdownDocument, Content, ContentSection
 import frontmatter
+
+
+class TestContentSection:
+    """Tests for the ContentSection class."""
+
+    def test_initialization(self):
+        """Verifies that ContentSection initializes with correct attributes."""
+        section = ContentSection(title="Intro", level=1)
+        assert section.title == "Intro"
+        assert section.level == 1
+        assert section.content == []
+
+    def test_add_single_string_content(self):
+        """Verifies adding a single string to the section content."""
+        section = ContentSection("Test", 1)
+        section.add_content("Line 1")
+        assert len(section.content) == 1
+        assert section.content[0] == "Line 1"
+
+    def test_add_list_content(self):
+        """Verifies adding a list of strings to the section content."""
+        section = ContentSection("Test", 1)
+        input_list = ["Line A", "Line B"]
+        section.add_content(input_list)
+        assert len(section.content) == 2
+        assert section.content == input_list
+
+    def test_add_mixed_content(self):
+        """Verifies adding both single strings and lists sequentially."""
+        section = ContentSection("Test", 1)
+        section.add_content("Start")
+        section.add_content(["Middle 1", "Middle 2"])
+        section.add_content("End")
+
+        expected = ["Start", "Middle 1", "Middle 2", "End"]
+        assert section.content == expected
+
+
+class TestContent:
+    """Tests for the Content class."""
+
+    @pytest.fixture
+    def content_manager(self):
+        """Fixture that returns a fresh Content instance."""
+        return Content()
+
+    def test_new_section_creation(self, content_manager):
+        """Verifies creating a new section via new_section method."""
+        content_manager.new_section("Chapter 1", 1)
+        assert "Chapter 1" in content_manager.sections
+        assert content_manager.sections["Chapter 1"].level == 1
+
+    def test_duplicate_section_ignored(self, content_manager):
+        """Verifies that creating a section with an existing title does not overwrite it."""
+        content_manager.new_section("Unique", 1)
+        # Try to add same title with different level
+        content_manager.new_section("Unique", 2)
+
+        # Should still be level 1 (original)
+        assert content_manager.sections["Unique"].level == 1
+
+    def test_add_existing_section_object(self, content_manager):
+        """Verifies adding a pre-instantiated ContentSection object."""
+        section = ContentSection("Manual Section", 2)
+        section.add_content("Some text")
+
+        content_manager.add_section(section)
+
+        assert "Manual Section" in content_manager.sections
+        assert content_manager.sections["Manual Section"].content == ["Some text"]
+
+    def test_add_content_creates_section_if_missing(self, content_manager):
+        """Verifies that add_content creates a section if it doesn't exist."""
+        content_manager.add_content(
+            "Auto text", section_title="Auto Created", section_level=3
+        )
+
+        assert "Auto Created" in content_manager.sections
+        assert content_manager.sections["Auto Created"].level == 3
+        assert content_manager.sections["Auto Created"].content == ["Auto text"]
+
+    def test_add_content_to_default_section(self, content_manager):
+        """Verifies adding content to the default section."""
+        content_manager.add_content("Intro text")  # Defaults to "default"
+
+        assert "default" in content_manager.sections
+        assert content_manager.sections["default"].content == ["Intro text"]
+
+    def test_to_string_formatting(self, content_manager):
+        """Verifies the Markdown serialization logic."""
+        # 1. Add default content (should have no header)
+        content_manager.add_content("Preface line.")
+
+        # 2. Add level 1 section
+        content_manager.add_content(
+            "Main body text.", section_title="Main", section_level=1
+        )
+
+        # 3. Add level 2 section via list
+        content_manager.add_content(
+            ["Sub point 1", "Sub point 2"], section_title="Sub", section_level=2
+        )
+
+        output = content_manager.to_string()
+
+        # Expected format:
+        # Preface line.
+        #
+        # # Main
+        # Main body text.
+        #
+        # ## Sub
+        # Sub point 1
+        # Sub point 2
+
+        expected_snippets = [
+            "Preface line.",
+            "# Main",
+            "Main body text.",
+            "## Sub",
+            "Sub point 1",
+            "Sub point 2",
+        ]
+
+        for snippet in expected_snippets:
+            assert snippet in output
+
+    def test_to_string_empty(self, content_manager):
+        """Verifies to_string returns empty string if no content exists."""
+        assert content_manager.to_string() == ""
 
 
 def test_init_without_metadata():

--- a/tests/markdown/test_zettelkasten.py
+++ b/tests/markdown/test_zettelkasten.py
@@ -1,7 +1,11 @@
 import pytest
 import os
-from ures.markdown.zettelkasten import (
+import sys
+from unittest.mock import MagicMock, patch
+from ures.markdown import (
     Zettelkasten,
+    Content,
+    ContentSection,
 )  # Adjust based on your project structure
 import frontmatter
 
@@ -304,3 +308,142 @@ def test_zettelkasten_clear_frontmatter(valid_zettelkasten):
     # Attempting to clear front matter should raise ValueError because mandatory fields are missing
     valid_zettelkasten.clear_frontmatter()
     assert valid_zettelkasten.metadata == {}
+
+
+# Mocking ures module functions used in Zettelkasten.to_llm_friendly_content
+class TestZettelkastenLLMFriendly:
+
+    @pytest.fixture
+    def sample_zettel(self):
+        """
+        Fixture to create a standard Zettelkasten note for testing.
+        """
+        zk = Zettelkasten(
+            title="Test Note",
+            n_type="permanent",
+            url="http://example.com",
+            tags=["coding", "testing"],
+            aliases=["test_alias"],
+            custom_field="custom_value",
+        )
+        zk.content = (
+            "# Header 1\nContent under header 1.\n\n# Header 2\nContent under header 2."
+        )
+        return zk
+
+    def test_default_metadata_filtering(self, sample_zettel):
+        """
+        Test that default fields (aliases, url, id, title) are excluded from the output.
+        """
+        # Act
+        llm_content = sample_zettel.to_llm_friendly_content()
+
+        # Convert to string for easy assertion checking
+        output_str = llm_content.to_string()
+
+        # Assert
+        assert "Metadata" in output_str
+        assert "**title**:" not in output_str
+        assert "**url**:" not in output_str
+        assert "**id**:" not in output_str
+        assert "**aliases**:" not in output_str
+
+        # Check that non-ignored fields are present
+        assert "**type**: permanent" in output_str
+        assert "**custom_field**: custom_value" in output_str
+
+    def test_prop_ignores_functionality(self, sample_zettel):
+        """
+        Test that providing `prop_ignores` correctly excludes additional metadata fields.
+        """
+        # Act
+        # We explicitly ask to ignore 'type' and 'create' in addition to defaults
+        llm_content = sample_zettel.to_llm_friendly_content(
+            prop_ignores=["type", "create", "custom_field"]
+        )
+        output_str = llm_content.to_string()
+
+        # Assert
+        assert "**type**:" not in output_str
+        assert "**create**:" not in output_str
+        assert "**custom_field**:" not in output_str
+
+        # Tags should still be there as they weren't ignored
+        assert "**tags**:" in output_str
+
+    def test_list_metadata_formatting(self, sample_zettel):
+        """
+        Test that metadata fields which are lists are converted to comma-separated strings.
+        """
+        # Act
+        llm_content = sample_zettel.to_llm_friendly_content()
+        output_str = llm_content.to_string()
+
+        # Assert
+        # tags=['coding', 'testing'] should become "coding, testing"
+        assert "**tags**: coding, testing" in output_str
+
+    def test_main_content_structure(self, sample_zettel):
+        """
+        Test that the main body content is correctly parsed and included.
+        """
+        # Act
+        llm_content = sample_zettel.to_llm_friendly_content()
+
+        # Access the raw sections to verify structure accurately
+        sections = llm_content.sections
+
+        # Assert
+        assert "Main Content" in sections
+        main_content_lines = sections["Main Content"].content
+
+        # Check for the header formatting logic defined in the method
+        # logic: content.add_content(content=f"**{key}**:", ...)
+        assert "**Header 1**:" in main_content_lines
+        assert "Content under header 1." in main_content_lines
+        assert "**Header 2**:" in main_content_lines
+
+    def test_context_integration(self, sample_zettel):
+        """
+        Test that external context is correctly appended to the content when provided.
+        """
+        # Arrange
+        context = Content()
+        context.add_content(
+            "Relevant info from another note.", section_title="Related Note"
+        )
+
+        # Act
+        llm_content = sample_zettel.to_llm_friendly_content(context=context)
+        output_str = llm_content.to_string()
+
+        # Assert
+        # Check if Context section header exists (handled by Content.to_string usually)
+        # or check specific formatting logic inside to_llm_friendly_content
+
+        # Logic:
+        # section_title="Context", section_level=2
+        # content=f"**{key}**:" (where key is "Related Note")
+
+        assert "## Context" in output_str
+        assert "**Related Note**:" in output_str
+        assert "Relevant info from another note." in output_str
+
+    def test_empty_content_and_context(self):
+        """
+        Test method behavior when the note has no content and no context is provided.
+        """
+        # Arrange
+        zk = Zettelkasten(title="Empty Note", n_type="fleeting")
+        zk.clear_content()  # Ensure no body content
+
+        # Act
+        llm_content = zk.to_llm_friendly_content()
+        output_str = llm_content.to_string()
+
+        # Assert
+        assert "# Metadata" in output_str
+        assert "**type**: fleeting" in output_str
+        # Main content section might exist but be empty or contain only default section
+        # Depending on how parse_content handles empty strings
+        assert "## Context" not in output_str

--- a/ures/markdown/__init__.py
+++ b/ures/markdown/__init__.py
@@ -1,4 +1,4 @@
-from .manipulator import MarkdownDocument
+from .manipulator import MarkdownDocument, Content, ContentSection
 from .zettelkasten import Zettelkasten
 
-__all__ = ["MarkdownDocument", "Zettelkasten"]
+__all__ = ["MarkdownDocument", "Zettelkasten", "Content", "ContentSection"]

--- a/ures/markdown/manipulator.py
+++ b/ures/markdown/manipulator.py
@@ -1,8 +1,106 @@
 import os
+import re
 import frontmatter
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Optional, List, AnyStr, Union
 from copy import deepcopy
+
+
+class ContentSection:
+    """Represents a specific section within a note, containing a title, hierarchy level, and text content.
+
+    Attributes:
+        title (str): The title of the section (e.g., "Introduction").
+        level (int): The heading level of the section (e.g., 1 for #, 2 for ##).
+        content (List[str]): A list of strings representing the lines of content in this section.
+    """
+
+    def __init__(self, title: str, level: int):
+        """Initializes a ContentSection with a title and a heading level.
+
+        Args:
+            title (str): The title of the section.
+            level (int): The Markdown heading level (e.g., 1, 2, 3).
+        """
+        self.title = title
+        self.level = level
+        self.content: List[str] = []
+
+    def add_content(self, content: Union[str, List[str]]):
+        """Appends text content to this section.
+
+        Args:
+            content (Union[str, List[str]]): A single string line or a list of string lines to add.
+        """
+        if isinstance(content, list):
+            self.content.extend(content)
+        else:
+            self.content.append(content)
+
+
+class Content:
+    """Represents the body of a note, organized into titled sections.
+
+    Attributes:
+        sections (Dict[str, ContentSection]): A dictionary mapping section titles to ContentSection objects.
+    """
+
+    def __init__(self):
+        """Initializes an empty Content container."""
+        self.sections: OrderedDict[str, ContentSection] = OrderedDict()
+
+    def new_section(self, title: str, level: int):
+        """Creates a new empty section if it does not already exist.
+
+        Args:
+            title (str): The unique title of the section.
+            level (int): The Markdown heading level for the section.
+        """
+        if title not in self.sections:
+            self.sections[title] = ContentSection(title, level)
+
+    def add_section(self, section: ContentSection):
+        """Adds an existing ContentSection object to the content.
+
+        If a section with the same title already exists, this operation is ignored.
+
+        Args:
+            section (ContentSection): The section object to add.
+        """
+        if section.title not in self.sections.keys():
+            self.sections[section.title] = section
+
+    def add_content(
+        self,
+        content: Union[str, list],
+        section_title: str = "default",
+        section_level: int = 1,
+    ):
+        """Adds content to a specific section, creating the section if it does not exist.
+
+        Args:
+            content (str, list): The text content to add.
+            section_title (str, optional): The title of the target section. Defaults to "default".
+            section_level (int, optional): The heading level if a new section needs to be created. Defaults to 1.
+        """
+        if section_title not in self.sections:
+            self.new_section(section_title, section_level)
+        self.sections[section_title].add_content(content)
+
+    def to_string(self) -> str:
+        """Serializes the entire content into a Markdown-formatted string.
+
+        Returns:
+            str: The complete Markdown content with section headers.
+        """
+        markdown_lines: List[str] = []
+        for section in self.sections.values():
+            if section.title != "default":
+                markdown_lines.append(f"{'#' * section.level} {section.title}")
+            markdown_lines.extend(section.content)
+            markdown_lines.append("")  # Add a blank line after each section
+        return "\n".join(markdown_lines).strip()
 
 
 class MarkdownDocument:
@@ -434,6 +532,52 @@ class MarkdownDocument:
 
         self.post.content = post.content
         self.post.metadata = deepcopy(post.metadata)
+
+    def parse_content(self) -> Content:
+        """Parses the raw note content into a structured Content object.
+
+        Iterates through the raw text line by line, identifying Markdown headers
+        (e.g., '# Title') to delimit sections. Text found before the first header
+        is assigned to a 'default' section.
+
+        Returns:
+            Content: An object containing the parsed sections, their hierarchy levels,
+            and associated text content.
+        """
+        lines = self.content.split("\n")
+        current_section = "default"
+        current_head_level = 1
+        content_buffer: List[str] = []
+        new_content = Content()
+
+        for line in lines:
+            header_match = re.match(r"^(#+)\s+(.+)$", line)
+
+            if header_match:
+                if len(content_buffer) > 0:
+                    new_content.add_content(
+                        content="\n".join(content_buffer).strip(),
+                        section_title=current_section,
+                        section_level=current_head_level,
+                    )
+                    content_buffer = []
+
+                current_head_level = len(header_match.group(1))
+                current_section = header_match.group(2).strip()
+
+                new_content.new_section(title=current_section, level=current_head_level)
+            else:
+                if line.strip() or len(content_buffer) > 0:
+                    content_buffer.append(line)
+
+        if len(content_buffer) > 0:
+            new_content.add_content(
+                content="\n".join(content_buffer).strip(),
+                section_title=current_section,
+                section_level=current_head_level,
+            )
+
+        return new_content
 
     def clear_content(self) -> None:
         """

--- a/ures/markdown/zettelkasten.py
+++ b/ures/markdown/zettelkasten.py
@@ -1,8 +1,8 @@
 import os
-from typing import Optional
+from typing import Optional, Union
 from ures.timedate import time_now
 from ures.string import zettelkasten_id
-from .manipulator import MarkdownDocument, frontmatter
+from .manipulator import MarkdownDocument, frontmatter, Content
 
 
 class Zettelkasten(MarkdownDocument):
@@ -62,7 +62,7 @@ class Zettelkasten(MarkdownDocument):
         super().__init__(metadata=_metadata)
 
     @classmethod
-    def from_file(cls, file_path: str) -> "MarkdownDocument":
+    def from_file(cls, file_path: str) -> Union["MarkdownDocument", "Zettelkasten"]:
         """
         Creates a MarkdownDocument instance by loading a Markdown file.
 
@@ -163,3 +163,75 @@ class Zettelkasten(MarkdownDocument):
 
     def remove_alias(self, alias: str):
         self.aliases.remove(alias)
+
+    def to_llm_friendly_content(
+        self, prop_ignores: Optional[list] = None, context: Optional[Content] = None
+    ) -> Content:
+        """Generates an LLM-friendly representation of the note, filtering metadata and merging context.
+
+        This method creates a structured content object designed for LLM consumption. It first
+        adds a 'Metadata' section (filtering out specified keys), then appends the note's
+        main body, and finally merges any external context provided.
+
+        Args:
+            prop_ignores (Optional[List[str]]): A list of metadata keys to exclude from the output.
+                Defaults to None. The keys "aliases", "url", "id", and "title" are always ignored
+                by default.
+            context (Optional[Content]): Additional contextual content to append to the note.
+                Defaults to None.
+
+        Returns:
+            Content: A new Content object organized into 'Metadata', 'Main Content', and
+            optionally 'Context' sections.
+        """
+        properties = self.metadata
+        content = Content()
+        # Create a new section for metadata
+        properties_ignore_list = ["aliases", "url", "id", "title"]
+        if prop_ignores:
+            properties_ignore_list.extend(prop_ignores)
+        for key, value in properties.items():
+            if key not in properties_ignore_list:
+                if isinstance(value, list):
+                    value = ", ".join(value)
+                else:
+                    value = str(value)
+
+                content.add_content(
+                    content=f"**{key}**: {value}",
+                    section_title="Metadata",
+                    section_level=1,
+                )
+
+        # Merge all existing sections into the main body
+        body_title = "Main Content"
+        body_level = 1
+        for key, value in self.parse_content().sections.items():
+            content.add_content(
+                content=f"**{key}**:",
+                section_title=body_title,
+                section_level=body_level,
+            )
+            content.add_content(
+                content=value.content,
+                section_title=body_title,
+                section_level=body_level,
+            )
+
+        # If context is provided, merge it
+        if context:
+            context_title = "Context"
+            context_level = 2
+            for key, value in context.sections.items():
+                content.add_content(
+                    content=f"**{key}**:",
+                    section_title=context_title,
+                    section_level=context_level,
+                )
+                content.add_content(
+                    content=value.content,
+                    section_title=context_title,
+                    section_level=context_level,
+                )
+
+        return content


### PR DESCRIPTION
this PR adds a utility method to_llm_friendly_content designed to serialize notes into a format optimized for Large Language Model (LLM) context windows, allowing for metadata filtering and context injection.

As we integrate AI workflows into the Zettelkasten system, raw Markdown files often contain excessive metadata (like internal IDs or file paths) that consume context tokens without adding value to the model.